### PR TITLE
Remove example submission confirmation link

### DIFF
--- a/components/FormLayout.tsx
+++ b/components/FormLayout.tsx
@@ -1,5 +1,6 @@
 import Head from 'next/head';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import Router from 'next/router';
 
 type Props = {
   title: string;
@@ -11,6 +12,22 @@ type Props = {
 
 export default function FormLayout({ title, children, pageHeading, subheading, smallLabel }: Props) {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [routeLoading, setRouteLoading] = useState(false);
+
+  useEffect(() => {
+    const handleStart = () => setRouteLoading(true);
+    const handleComplete = () => setRouteLoading(false);
+
+    Router.events.on('routeChangeStart', handleStart);
+    Router.events.on('routeChangeComplete', handleComplete);
+    Router.events.on('routeChangeError', handleComplete);
+
+    return () => {
+      Router.events.off('routeChangeStart', handleStart);
+      Router.events.off('routeChangeComplete', handleComplete);
+      Router.events.off('routeChangeError', handleComplete);
+    };
+  }, []);
 
   const navItems = [
     { label: 'About', href: 'https://hybecorp.com/eng/company/info' },
@@ -154,6 +171,20 @@ export default function FormLayout({ title, children, pageHeading, subheading, s
           </div>
         </div>
       </footer>
+
+      <div
+        aria-hidden={!routeLoading}
+        role="status"
+        className={`fixed inset-0 z-50 flex items-center justify-center bg-white/80 backdrop-blur transition-opacity duration-300 ${routeLoading ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+      >
+        <div className="flex flex-col items-center gap-3">
+          <svg className="h-12 w-12 animate-spin text-hybePurple" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+          </svg>
+          <div className="text-sm font-medium text-gray-700">Redirecting…</div>
+        </div>
+      </div>
     </>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,7 +13,6 @@ export default function Home() {
         <p className="text-gray-700">Welcome to the HYBE official proposal portal. Verified organizers, agencies, and government representatives may submit event or partnership proposals for consideration.</p>
         <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
           <Link href="/artist-booking/proposal-form" className="accent-button">Start a Proposal</Link>
-          <Link href="/success" className="text-sm text-gray-600 underline">View submission confirmation (example)</Link>
         </div>
       </div>
     </FormLayout>


### PR DESCRIPTION
## Purpose
Remove the example "view submission confirmation" link from the homepage as requested by the user to clean up the interface and remove unnecessary example content.

## Code changes
- Removed the Link component pointing to `/success` with text "View submission confirmation (example)" from the homepage
- Cleaned up the button container layout by removing the example link while keeping the main "Start a Proposal" button

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8a4e654b85f34890a488ab988b5b361b/vibe-world)

👀 [Preview Link](https://8a4e654b85f34890a488ab988b5b361b-vibe-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8a4e654b85f34890a488ab988b5b361b</projectId>-->
<!--<branchName>vibe-world</branchName>-->