### PR TITLE
Replace @netlify/plugin-nextjs v5 with @netlify/next

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@
   publish = ".next"
 
 [[plugins]]
-  package = "@netlify/plugin-nextjs"
+  package = "@netlify/next"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "@netlify/plugin-nextjs": "^5.6.0",
     "@types/node": "^20.11.24",
     "@types/react": "^18.2.48",
     "autoprefixer": "^10.4.17",


### PR DESCRIPTION
## Purpose

Update the Netlify deployment configuration to use the newer `@netlify/next` plugin instead of the deprecated `@netlify/plugin-nextjs` v5. This change ensures the Next.js app uses the correct Netlify runtime and follows current best practices for Netlify deployments.

## Code changes

- **netlify.toml**: Updated plugin package from `@netlify/plugin-nextjs` to `@netlify/next`
- **package.json**: Removed `@netlify/plugin-nextjs` v5.6.0 from devDependencies

This migration aligns with Netlify's recommended approach for Next.js applications and should improve deployment reliability.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8a4e654b85f34890a488ab988b5b361b/orbit-field)

👀 [Preview Link](https://8a4e654b85f34890a488ab988b5b361b-orbit-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8a4e654b85f34890a488ab988b5b361b</projectId>-->
<!--<branchName>orbit-field</branchName>-->