### PR TITLE
Fix: Resolve proposal form submission failures

### DIFF
--- a/pages/artist-booking/proposal-form.tsx
+++ b/pages/artist-booking/proposal-form.tsx
@@ -100,31 +100,6 @@ export default function ProposalFormPage() {
     setConfirmOpen(true);
   }
 
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    if (submitting) return;
-    setSubmitError(null);
-    setSubmitting(true);
-
-    const form = e.currentTarget;
-    const data = new FormData(form);
-
-    try {
-      const res = await fetch(window.location.pathname, {
-        method: 'POST',
-        body: data,
-      });
-
-      if (!res.ok) throw new Error('Network response was not ok');
-
-      // Redirect to success page after Netlify receives the submission
-      window.location.href = '/success';
-    } catch (err) {
-      console.error(err);
-      setSubmitError('Submission failed. Please try again.');
-      setSubmitting(false);
-    }
-  }
 
   async function handleDocChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -176,7 +151,8 @@ export default function ProposalFormPage() {
         className="space-y-8"
         action="/success"
         encType="multipart/form-data"
-        onSubmit={handleSubmit}
+        data-netlify="true"
+        netlify-honeypot="bot-field"
       >
         <input type="hidden" name="form-name" value="artist-proposal" />
         <p className="hidden">
@@ -428,7 +404,7 @@ export default function ProposalFormPage() {
               </div>
               <div className="mt-6 flex justify-end gap-3">
                 <button type="button" className="btn-secondary" onClick={() => setConfirmOpen(false)}>Edit</button>
-                <button type="button" className="accent-button" onClick={() => { setConfirmOpen(false); formRef.current?.requestSubmit(); }} disabled={submitting}>
+                <button type="button" className="accent-button" onClick={() => { setSubmitting(true); setConfirmOpen(false); formRef.current?.requestSubmit(); }} disabled={submitting}>
                   {submitting ? 'Submitting…' : 'Confirm & Submit'}
                 </button>
               </div>


### PR DESCRIPTION
### Purpose

This pull request addresses an issue where the artist proposal form was failing with a "Submission failed. Please try again." error, preventing users from successfully submitting their proposals. The goal is to fix the submission mechanism to ensure reliability.

### Code changes

- Removed the manual `fetch`-based `handleSubmit` function.
- Refactored the form to use standard Netlify form handling by adding `data-netlify="true"` and `netlify-honeypot="bot-field"` attributes.
- The form now submits directly to the `/success` page as declared in the `action` attribute, handled by Netlify.
- Ensured the "Submitting..." state is correctly displayed when the user confirms the submission.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8b88a3a4985949869c77fa208a7e1802/flare-landing)

👀 [Preview Link](https://8b88a3a4985949869c77fa208a7e1802-flare-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8b88a3a4985949869c77fa208a7e1802</projectId>-->
<!--<branchName>flare-landing</branchName>-->